### PR TITLE
#6 券種と馬番の選択をできるようにした

### DIFF
--- a/src/features/tickets/AddTicketForm.tsx
+++ b/src/features/tickets/AddTicketForm.tsx
@@ -8,14 +8,24 @@ function AddTicketForm() {
   const [date, setDate] = useState<string>("");
   const [racetrack, setRacetrack] = useState<string>("");
   const [raceNumber, setRaceNumber] = useState<string>("");
+  const [typeName, setTypeName] = useState<string>("");
+  const [typeNumbers, setTypeNumbers] = useState<string[]>([]);
   const [betAmount, setBetAmount] = useState<string>("");
   const [payout, setPayout] = useState<string>("");
 
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const onSaveTicketClicked = () => {
-    if (date && racetrack && raceNumber && betAmount && payout) {
+  const onSaveClicked = () => {
+    if (
+      date &&
+      racetrack &&
+      raceNumber &&
+      typeName &&
+      typeNumbers.length !== 0 &&
+      betAmount &&
+      payout
+    ) {
       dispatch(
         ticketAdded({
           id: nanoid(),
@@ -23,6 +33,8 @@ function AddTicketForm() {
           date,
           racetrack,
           raceNumber,
+          typeName,
+          typeNumbers,
           betAmount,
           payout,
         })
@@ -30,6 +42,8 @@ function AddTicketForm() {
       setDate("");
       setRacetrack("");
       setRaceNumber("");
+      setTypeName("");
+      setTypeNumbers([]);
       setBetAmount("");
       setPayout("");
       navigate("/");
@@ -44,37 +58,67 @@ function AddTicketForm() {
         placeholder="日付"
         onChange={(e) => setDate(e.target.value)}
       />
-      <select
-        name=""
-        id=""
-        value={racetrack}
-        onChange={(e) => setRacetrack(e.target.value)}
-      >
-        <option value="">未選択</option>
+      <select value={racetrack} onChange={(e) => setRacetrack(e.target.value)}>
+        <option value="">競馬場</option>
         <option value="京都">京都</option>
         <option value="東京">東京</option>
         <option value="新潟">新潟</option>
       </select>
       <select
-        name=""
-        id=""
         value={raceNumber}
         onChange={(e) => setRaceNumber(e.target.value)}
       >
-        <option value="">未選択</option>
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
-        <option value="4">4</option>
-        <option value="5">5</option>
-        <option value="6">6</option>
-        <option value="7">7</option>
-        <option value="8">8</option>
-        <option value="9">9</option>
-        <option value="10">10</option>
-        <option value="11">11</option>
-        <option value="12">12</option>
+        <option value="">レース</option>
+        <option value="1">1R</option>
+        <option value="2">2R</option>
+        <option value="3">3R</option>
+        <option value="4">4R</option>
+        <option value="5">5R</option>
+        <option value="6">6R</option>
+        <option value="7">7R</option>
+        <option value="8">8R</option>
+        <option value="9">9R</option>
+        <option value="10">10R</option>
+        <option value="11">11R</option>
+        <option value="12">12R</option>
       </select>
+      <select value={typeName} onChange={(e) => setTypeName(e.target.value)}>
+        <option value="">券種</option>
+        <option value="単勝">単勝</option>
+        <option value="馬連">馬連</option>
+        <option value="三連単">三連単</option>
+      </select>
+      <label>
+        馬番
+        <select
+          value={typeNumbers}
+          multiple={true}
+          onChange={(e) => {
+            const options = [...e.target.selectedOptions];
+            const values = options.map((option) => option.value);
+            setTypeNumbers(values);
+          }}
+        >
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
+          <option value="11">11</option>
+          <option value="12">12</option>
+          <option value="13">13</option>
+          <option value="14">14</option>
+          <option value="15">15</option>
+          <option value="16">16</option>
+          <option value="17">17</option>
+          <option value="18">18</option>
+        </select>
+      </label>
       <input
         type="number"
         value={betAmount ?? ""}
@@ -87,7 +131,7 @@ function AddTicketForm() {
         placeholder="払い戻し金額"
         onChange={(e) => setPayout(e.target.value)}
       />
-      <button type="button" onClick={onSaveTicketClicked}>
+      <button type="button" onClick={onSaveClicked}>
         馬券を追加
       </button>
       <button

--- a/src/features/tickets/EditTicketForm.tsx
+++ b/src/features/tickets/EditTicketForm.tsx
@@ -13,6 +13,8 @@ export default function EditTicketForm() {
   const [date, setDate] = useState<string>(ticket?.date);
   const [racetrack, setRacetrack] = useState<string>(ticket?.racetrack);
   const [raceNumber, setRaceNumber] = useState<string>(ticket?.raceNumber);
+  const [typeName, setTypeName] = useState<string>(ticket?.typeName);
+  const [typeNumbers, setTypeNumbers] = useState<string[]>(ticket?.typeNumbers);
   const [betAmount, setBetAmount] = useState<string>(ticket?.betAmount);
   const [payout, setPayout] = useState<string>(ticket?.payout);
 
@@ -20,7 +22,15 @@ export default function EditTicketForm() {
   const navigate = useNavigate();
 
   const onSaveTicketClicked = () => {
-    if (date && racetrack && raceNumber && betAmount && payout) {
+    if (
+      date &&
+      racetrack &&
+      raceNumber &&
+      typeName &&
+      typeNumbers.length !== 0 &&
+      betAmount &&
+      payout
+    ) {
       dispatch(
         ticketUpdated({
           id: ticketId,
@@ -28,6 +38,8 @@ export default function EditTicketForm() {
           date,
           racetrack,
           raceNumber,
+          typeName,
+          typeNumbers,
           betAmount,
           payout,
         })
@@ -35,6 +47,8 @@ export default function EditTicketForm() {
       setDate("");
       setRacetrack("");
       setRaceNumber("");
+      setTypeName("");
+      setTypeNumbers([]);
       setBetAmount("");
       setPayout("");
       navigate(`/tickets/${ticketId}`);
@@ -49,37 +63,70 @@ export default function EditTicketForm() {
         placeholder="日付"
         onChange={(e) => setDate(e.target.value)}
       />
-      <select
-        name=""
-        id=""
-        value={racetrack}
-        onChange={(e) => setRacetrack(e.target.value)}
-      >
-        <option value="">未選択</option>
+      <select value={racetrack} onChange={(e) => setRacetrack(e.target.value)}>
+        <option value="">競馬場</option>
         <option value="京都">京都</option>
         <option value="東京">東京</option>
         <option value="新潟">新潟</option>
       </select>
       <select
-        name=""
-        id=""
         value={raceNumber}
         onChange={(e) => setRaceNumber(e.target.value)}
       >
-        <option value="">未選択</option>
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
-        <option value="4">4</option>
-        <option value="5">5</option>
-        <option value="6">6</option>
-        <option value="7">7</option>
-        <option value="8">8</option>
-        <option value="9">9</option>
-        <option value="10">10</option>
-        <option value="11">11</option>
-        <option value="12">12</option>
+        <option value="">レース</option>
+        <option value="1">1R</option>
+        <option value="2">2R</option>
+        <option value="3">3R</option>
+        <option value="4">4R</option>
+        <option value="5">5R</option>
+        <option value="6">6R</option>
+        <option value="7">7R</option>
+        <option value="8">8R</option>
+        <option value="9">9R</option>
+        <option value="10">10R</option>
+        <option value="11">11R</option>
+        <option value="12">12R</option>
       </select>
+      <select
+        value={typeName ?? ""}
+        onChange={(e) => setTypeName(e.target.value)}
+      >
+        <option value="">券種</option>
+        <option value="単勝">単勝</option>
+        <option value="馬連">馬連</option>
+        <option value="三連単">三連単</option>
+      </select>
+      <label>
+        馬番
+        <select
+          value={typeNumbers.length === 0 ? [] : typeNumbers}
+          multiple={true}
+          onChange={(e) => {
+            const options = [...e.target.selectedOptions];
+            const values = options.map((option) => option.value);
+            setTypeNumbers(values);
+          }}
+        >
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
+          <option value="11">11</option>
+          <option value="12">12</option>
+          <option value="13">13</option>
+          <option value="14">14</option>
+          <option value="15">15</option>
+          <option value="16">16</option>
+          <option value="17">17</option>
+          <option value="18">18</option>
+        </select>
+      </label>
       <input
         type="number"
         value={betAmount ?? ""}

--- a/src/features/tickets/TicketsList.tsx
+++ b/src/features/tickets/TicketsList.tsx
@@ -25,16 +25,11 @@ function TicketsList() {
               )}
             </p>
             <p>{`${ticket.racetrack}${ticket.raceNumber}R`}</p>
-            <dl>
-              <div>
-                <dt>購入金額</dt>
-                <dd>￥{ticket.betAmount}</dd>
-              </div>
-              <div>
-                <dt>払い戻し金額</dt>
-                <dd>￥{ticket.payout}</dd>
-              </div>
-            </dl>
+            <p>
+              {ticket.typeName}：{ticket.typeNumbers.join(" - ")}
+            </p>
+            <p>購入金額：￥{ticket.betAmount}</p>
+            <p>払い戻し金額：￥{ticket.payout}</p>
             <button>編集</button>
             <button onClick={() => handleDelete(ticket.id)}>削除</button>
           </Link>

--- a/src/features/tickets/ticketsSlice.ts
+++ b/src/features/tickets/ticketsSlice.ts
@@ -2,35 +2,39 @@ import { createSlice } from "@reduxjs/toolkit";
 
 export type ticketState = {
   id: string;
-  createDate: string;
-  updateDate: string;
+  createDate: number;
+  updateDate: number;
   date: string;
   racetrack: string;
-  raceNumber: number;
-  betAmount: number;
-  payout: number;
+  raceNumber: string;
+  betAmount: string;
+  payout: string;
 };
 
 const initialState = [
   {
     id: "1",
-    createDate: "1716107513229",
-    updateDate: "",
+    createDate: 1716107513229,
+    updateDate: -1,
     date: "2024-05-18",
     racetrack: "京都",
     raceNumber: "5",
-    betAmount: 100,
-    payout: 200,
+    typeName: "単勝",
+    typeNumbers: ["1"],
+    betAmount: "200",
+    payout: "1000",
   },
   {
     id: "2",
-    createDate: "1716107513229",
-    updateDate: "",
+    createDate: 1716107513229,
+    updateDate: -1,
     date: "2024-05-18",
     racetrack: "京都",
     raceNumber: "5",
-    betAmount: 100,
-    payout: 200,
+    typeName: "三連単",
+    typeNumbers: ["1", "8", "15"],
+    betAmount: "500",
+    payout: "200000",
   },
 ];
 
@@ -48,14 +52,25 @@ const ticketsSlice = createSlice({
       return filteredTicketsList;
     },
     ticketUpdated(state, action) {
-      const { id, updateDate, date, racetrack, raceNumber, betAmount, payout } =
-        action.payload;
+      const {
+        id,
+        updateDate,
+        date,
+        racetrack,
+        raceNumber,
+        typeName,
+        typeNumbers,
+        betAmount,
+        payout,
+      } = action.payload;
       const existingTicket = state.find((ticket) => ticket.id === id);
       if (existingTicket) {
         existingTicket.updateDate = updateDate;
         existingTicket.date = date;
         existingTicket.racetrack = racetrack;
         existingTicket.raceNumber = raceNumber;
+        existingTicket.typeName = typeName;
+        existingTicket.typeNumbers = typeNumbers;
         existingTicket.betAmount = betAmount;
         existingTicket.payout = payout;
       }

--- a/src/routes/SingleTicket.tsx
+++ b/src/routes/SingleTicket.tsx
@@ -24,16 +24,11 @@ export default function SingleTicket() {
         )}
       </p>
       <p>{`${ticket.racetrack}${ticket.raceNumber}R`}</p>
-      <dl>
-        <div>
-          <dt>購入金額</dt>
-          <dd>￥{ticket.betAmount}</dd>
-        </div>
-        <div>
-          <dt>払い戻し金額</dt>
-          <dd>￥{ticket.payout}</dd>
-        </div>
-      </dl>
+      <p>
+        {ticket.typeName}：{ticket.typeNumbers.join(" - ")}
+      </p>
+      <p>購入金額：￥{ticket.betAmount}</p>
+      <p>払い戻し金額：￥{ticket.payout}</p>
       <Link to={`/tickets/${ticket.id}/edit`}>編集</Link>
       <button>削除</button>
     </>


### PR DESCRIPTION
- typeNameとTypeNumbersをStateに追加
- 詳細ページ・一覧ページで表示できるようにした
- 追加・編集ページで入力欄とreducerに送るpayroadに追加した
- 追加・編集するreducerを改修した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - チケット追加フォームにチケットタイプと馬番号の選択機能を追加しました。
  - チケット編集フォームにチケットタイプと馬番号の選択機能を追加しました。

- **改善**
  - チケットリストの表示形式を変更し、チケットタイプ、馬番号、ベット金額、支払い金額を個別の段落で表示するようにしました。
  - チケット詳細表示のレイアウトを改善し、チケットタイプ、馬番号、購入金額、支払い金額を別々に表示し、編集・削除リンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->